### PR TITLE
[COOK-3739] Unable to Configure Many AppPool Settings

### DIFF
--- a/providers/pool.rb
+++ b/providers/pool.rb
@@ -29,6 +29,7 @@ action :add do
   cmd = "#{appcmd} add apppool /name:\"#{@new_resource.pool_name}\""
   cmd << " /managedRuntimeVersion:v#{@new_resource.runtime_version}" if @new_resource.runtime_version
   cmd << " /managedPipelineMode:#{@new_resource.pipeline_mode}" if @new_resource.pipeline_mode
+  cmd << @new_resource.properties if @new_resource.properties
   Chef::Log.debug(cmd)
   shell_out!(cmd)
   @new_resource.updated_by_last_action(true)
@@ -39,6 +40,11 @@ action :add do
 end
 
 action :config do
+  unless @new_resource.properties.nil?
+    cmd = "#{appcmd} set apppool \"/apppool.name:#{@new_resource.pool_name}\" #{@new_resource.properties}"
+    Chef::Log.debug(cmd)
+    shell_out!(cmd)
+  end
   cmd = "#{appcmd} set config /section:applicationPools "
   cmd << "\"/[name='#{@new_resource.pool_name}'].recycling.logEventOnRecycle:PrivateMemory,Memory,Schedule,Requests,Time,ConfigChange,OnDemand,IsapiUnhealthy\""
   Chef::Log.debug(cmd)

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -39,3 +39,12 @@ def initialize(*args)
   super
   @action = :add
 end
+
+def properties( arg=nil )
+  if arg.is_a?(Hash)
+    parameters = ''
+    arg.each { |property, value| parameters << " /#{property}:#{value}" }
+    arg = parameters
+  end
+  set_or_return(:properties, arg, :kind_of => [ String, Hash ])
+end


### PR DESCRIPTION
Jira : https://tickets.opscode.com/browse/COOK-3739
I have added in a way to provide arbitrary application pool properties as a hash.  The key's and values should match what would be used in the command:

```ruby
"autoStart" => "true", "recycling.periodicRestart.memory" => "512000"
```

This works well for me as it is straight forward to merge a hash from a data item over top cookbook defaults before passing along to the resource.