### PR TITLE
Cookbook dependency update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+/cookbooks
+/vendor/cookbooks/
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+site :opscode
+
+metadata

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,0 +1,25 @@
+{
+  "sources": {
+    "iis": {
+      "path": "."
+    },
+    "powershell": {
+      "locked_version": "3.0.0"
+    },
+    "windows": {
+      "locked_version": "1.30.0"
+    },
+    "chef_handler": {
+      "locked_version": "1.1.4"
+    },
+    "ms_dotnet45": {
+      "locked_version": "1.1.2"
+    },
+    "ms_dotnet4": {
+      "locked_version": "1.0.2"
+    },
+    "ms_dotnet2": {
+      "locked_version": "1.0.0"
+    }
+  }
+}

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,4 +6,5 @@ description      "Installs/Configures Microsoft Internet Information Services"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "2.0.1"
 supports         "windows"
-depends          "windows", ">= 1.2.6"
+depends          "powershell"
+depends          "windows"


### PR DESCRIPTION
Cookbook was failing on Vagrant converge because of Powershell dependency not being in older pinned version of windows cookbook.

Also added Berkshelf support and a new .gitignore.