### PR TITLE
Enhance IIS cookbook to include some missing configuration options

### DIFF
--- a/providers/app.rb
+++ b/providers/app.rb
@@ -54,6 +54,12 @@ action :config do
     Chef::Log.debug(cmd)
     shell_out!(cmd)
   end
+  
+  unless @new_resource.preload_enabled.nil?
+    cmd = "#{appcmd} set app \"#{vdir_identifier}\" /preloadEnabled:#{@new_resource.preload_enabled}"
+    Chef::Log.debug(cmd)
+    shell_out!(cmd)
+  end
 
 end
 

--- a/providers/pool.rb
+++ b/providers/pool.rb
@@ -90,6 +90,11 @@ action :config do
     Chef::Log.debug(cmd)
     shell_out!(cmd)
   end
+  unless @new_resource.start_mode.nil?
+    cmd = "#{appcmd} set apppool \"/apppool.name:#{@new_resource.pool_name}\" /startMode:#{@new_resource.start_mode}"
+    Chef::Log.debug(cmd) if @new_resource.start_mode
+    shell_out!(cmd)
+  end
 end
 
 action :delete do

--- a/providers/pool.rb
+++ b/providers/pool.rb
@@ -95,6 +95,11 @@ action :config do
     Chef::Log.debug(cmd) if @new_resource.start_mode
     shell_out!(cmd)
   end
+  unless @new_resource.auto_start.nil?
+    cmd = "#{appcmd} set apppool \"/apppool.name:#{@new_resource.pool_name}\" /autoStart:#{@new_resource.auto_start}"
+    Chef::Log.debug(cmd) if @new_resource.auto_start
+    shell_out!(cmd)
+  end
 end
 
 action :delete do

--- a/resources/app.rb
+++ b/resources/app.rb
@@ -25,6 +25,7 @@ attribute :path, :kind_of => String, :default => '/'
 attribute :application_pool, :kind_of => String
 attribute :physical_path, :kind_of => String
 attribute :enabled_protocols, :kind_of => String
+attribute :preload_enabled, :kind_of => [TrueClass, FalseClass], :default => false
 attr_accessor :exists, :running
 
 def initialize(*args)

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -34,6 +34,7 @@ attribute :thirty_two_bit, :kind_of => Symbol
 attribute :pool_username, :kind_of => String
 attribute :pool_password, :kind_of => String
 attribute :start_mode, :kind_of => Symbol, :equal_to => [:AlwaysRunning, :OnDemand]
+attribute :auto_start, :kind_of => [TrueClass, FalseClass], :default => true
 
 attr_accessor :exists, :running
 

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -33,6 +33,7 @@ attribute :max_proc, :kind_of => Integer
 attribute :thirty_two_bit, :kind_of => Symbol
 attribute :pool_username, :kind_of => String
 attribute :pool_password, :kind_of => String
+attribute :start_mode, :kind_of => Symbol, :equal_to => [:AlwaysRunning, :OnDemand]
 
 attr_accessor :exists, :running
 


### PR DESCRIPTION
The current LWRP for IIS are missing several options for configuring IIS. A few new options have been added.

### pool.rb
 * [startMode] - AlwaysRunning, OnDemand
 * [autoStart] - True, False

### app.rb
 * [preloadEnabled] - True, False

Ticket https://tickets.opscode.com/browse/COOK-4709