### PR TITLE
Fix. Make sure that `pipeline_mode' is always capitalized and `thirty_tw...

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Creates an application pool in IIS.
 - `recycle_after_time` - specifies a pool to recycle at regular time intervals, d.hh:mm:ss, d optional
 - `recycle_at_time` - schedule a pool to recycle at a specific time, d.hh:mm:ss, d optional
 - `max_proc` - specifies the number of worker processes associated with the pool.
-- `thirty_two_bit` - set the pool to run in 32 bit mode, :true or :false
+- `thirty_two_bit` - set the pool to run in 32 bit mode, valid values are :true or :false
 - `no_managed_code` - allow Unmanaged Code in setting up IIS app pools
 - `pool_username` - username for the identity for the application pool
 - `pool_password` password for the identity for the application pool

--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ Creates an application pool in IIS.
 
 - `pool_name` - name attribute. Specifies the name of the pool to create.
 - `runtime_version` - specifies what .NET version of the runtime to use.
-- `pipeline_mode` - specifies what pipeline mode to create the pool with
+- `pipeline_mode` - specifies what pipeline mode to create the pool with, valid values are :Integrated or :Classic, the default is :Integrated
 - `private_mem` - specifies the amount of private memory (in kilobytes) after which you want the pool to recycle
 - `worker_idle_timeout` - specifies the idle time-out value for a pool, d.hh:mm:ss, d optional
 - `recycle_after_time` - specifies a pool to recycle at regular time intervals, d.hh:mm:ss, d optional
 - `recycle_at_time` - schedule a pool to recycle at a specific time, d.hh:mm:ss, d optional
 - `max_proc` - specifies the number of worker processes associated with the pool.
-- `thirty_two_bit` - set the pool to run in 32 bit mode, true or false
+- `thirty_two_bit` - set the pool to run in 32 bit mode, :true or :false
 - `no_managed_code` - allow Unmanaged Code in setting up IIS app pools
 - `pool_username` - username for the identity for the application pool
 - `pool_password` password for the identity for the application pool

--- a/providers/pool.rb
+++ b/providers/pool.rb
@@ -29,7 +29,7 @@ action :add do
     cmd = "#{appcmd} add apppool /name:\"#{@new_resource.pool_name}\""
     cmd << " /managedRuntimeVersion:" if @new_resource.runtime_version || @new_resource.no_managed_code
     cmd << "v#{@new_resource.runtime_version}" if @new_resource.runtime_version && !@new_resource.no_managed_code
-    cmd << " /managedPipelineMode:#{@new_resource.pipeline_mode}" if @new_resource.pipeline_mode
+    cmd << " /managedPipelineMode:#{@new_resource.pipeline_mode.capitalize}" if @new_resource.pipeline_mode
     Chef::Log.debug(cmd)
     shell_out!(cmd)
     @new_resource.updated_by_last_action(true)
@@ -58,7 +58,7 @@ action :config do
     @new_resource.updated_by_last_action(true)
   end
   unless @new_resource.thirty_two_bit.nil?
-    cmd = "#{appcmd} set apppool \"/apppool.name:#{@new_resource.pool_name}\" /enable32BitAppOnWin64:#{@new_resource.thirty_two_bit}"
+    cmd = "#{appcmd} set apppool \"/apppool.name:#{@new_resource.pool_name}\" /enable32BitAppOnWin64:#{@new_resource.thirty_two_bit.downcase}"
     Chef::Log.debug(cmd)
     shell_out!(cmd)
     @new_resource.updated_by_last_action(true)


### PR DESCRIPTION
...o_bit' is always lower case.

This is to address confusion that some users have around how this suppose to be set.

Signed-off-by: Krzysztof Wilczynski <krzysztof.wilczynski@linux.com>