### PR TITLE
added app_pool identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Creates an application pool in IIS.
 - `max_proc` - specifies the number of worker processes associated with the pool.
 - `thirty_two_bit` - set the pool to run in 32 bit mode, true or false
 - `no_managed_code` - allow Unmanaged Code in setting up IIS app pools
+- `pool_identity` - the account identity that they app pool will run as
 - `pool_username` - username for the identity for the application pool
 - `pool_password` password for the identity for the application pool
 

--- a/providers/pool.rb
+++ b/providers/pool.rb
@@ -159,7 +159,7 @@ def load_current_resource
   if result
     @current_resource.exists = true
     @current_resource.running = (result[4] =~ /Started/) ? true : false
-    @current_resource.pool_identity(shell_out("#{appcmd} list apppool #{@current_resource.pool_name} /text:processModel.identityType").stdout.gsub(/\r\n?/, '').to_sym)
+    @current_resource.pool_identity(shell_out!("#{appcmd} list apppool #{@current_resource.pool_name} /text:processModel.identityType", {:returns => [0]}).stdout.gsub(/\r\n?/, '').to_sym)
   else
     @current_resource.exists = false
     @current_resource.running = false

--- a/providers/pool.rb
+++ b/providers/pool.rb
@@ -82,6 +82,12 @@ action :config do
     Chef::Log.debug(cmd)
     shell_out!(cmd)
   end
+  unless @new_resource.pool_identity.nil?
+    cmd = "#{appcmd} set config /section:applicationPools"
+    cmd << " \"/[name='#{@new_resource.pool_name}'].processModel.identityType:#{@new_resource.pool_identity}\""
+    Chef::Log.debug(cmd)
+    shell_out!(cmd)
+  end
   unless @new_resource.pool_username.nil? and @new_resource.pool_password.nil?
     cmd = "#{appcmd} set config /section:applicationPools"
     cmd << " \"/[name='#{@new_resource.pool_name}'].processModel.identityType:SpecificUser\""

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -31,6 +31,7 @@ attribute :recycle_after_time, :kind_of => String
 attribute :recycle_at_time, :kind_of => String
 attribute :max_proc, :kind_of => Integer
 attribute :thirty_two_bit, :kind_of => Symbol
+attribute :pool_identity, :kind_of => Symbol, :equal_to => [:SpecificUser, :NetworkService, :LocalService, :LocalSystem, :ApplicationPoolIdentity ]
 attribute :pool_username, :kind_of => String
 attribute :pool_password, :kind_of => String
 

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -31,7 +31,7 @@ attribute :recycle_after_time, :kind_of => String
 attribute :recycle_at_time, :kind_of => String
 attribute :max_proc, :kind_of => Integer
 attribute :thirty_two_bit, :kind_of => Symbol
-attribute :pool_identity, :kind_of => Symbol, :default => :ApplicationPoolIdentity, :equal_to => [:SpecificUser, :NetworkService, :LocalService, :LocalSystem, :ApplicationPoolIdentity ]
+attribute :pool_identity, :kind_of => Symbol, :equal_to => [:SpecificUser, :NetworkService, :LocalService, :LocalSystem, :ApplicationPoolIdentity ]
 attribute :pool_username, :kind_of => String
 attribute :pool_password, :kind_of => String
 

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -31,7 +31,7 @@ attribute :recycle_after_time, :kind_of => String
 attribute :recycle_at_time, :kind_of => String
 attribute :max_proc, :kind_of => Integer
 attribute :thirty_two_bit, :kind_of => Symbol
-attribute :pool_identity, :kind_of => Symbol, :equal_to => [:SpecificUser, :NetworkService, :LocalService, :LocalSystem, :ApplicationPoolIdentity ]
+attribute :pool_identity, :kind_of => Symbol, :default => :ApplicationPoolIdentity, :equal_to => [:SpecificUser, :NetworkService, :LocalService, :LocalSystem, :ApplicationPoolIdentity ]
 attribute :pool_username, :kind_of => String
 attribute :pool_password, :kind_of => String
 


### PR DESCRIPTION
This will allow you to change the app_pool identity to any of the allowed accounts:
SpecificUser, NetworkService, LocalService, LocalSystem, ApplicationPoolIdentity

To use a custom account you will set this to SpecificUser and then set "pool_username" and "pool_password", otherwise you can set it to one of the built in accounts NetworkService, LocalService, LocalSystem, ApplicationPoolIdentity