### PR TITLE
function is_new_or_empty bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v3.0.12 (2015-1-16)
+-------------------
+- Fixed issue [#107] function is_new_or_empty was returning reverse results.
+
 v3.0.11 (2015-1-14)
 -------------------
 - Removed BOM char from multiple files that was causing recipe compile errors

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -56,7 +56,7 @@ module Opscode
       end
 
       def is_new_or_empty_value?(document, xpath, value_to_check)
-        return is_new_value?(document, xpath, value_to_check) || value_to_check == '' ? false : true
+        return !is_new_value?(document, xpath, value_to_check) || value_to_check == '' ? false : true
       end
 
       def appcmd(node)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"
 description      "Installs/Configures Microsoft Internet Information Services"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.0.11"
+version          "3.0.12"
 supports         "windows"
 depends          "windows", ">= 1.34.6"


### PR DESCRIPTION
Fixed issue [#107] function is_new_or_empty was returning reverse results.

@smurawski this effects mainly second run `:config` runs but apparently my logic was backwards in this library.