### PR TITLE
Feature dotnet45

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ mod_*
 This cookbook also contains recipes for installing individual IIS modules (extensions).  These recipes can be included in a node's run_list to build the minimal desired custom IIS installation.
 
 * `mod_aspnet` - installs ASP.NET runtime components
+* `mod_aspnet45` - installs ASP.NET 4.5 runtime components
 * `mod_auth_basic` - installs Basic Authentication support
 * `mod_auth_windows` - installs Windows Authentication (authenticate clients by using NTLM or Kerberos) support
 * `mod_compress_dynamic` - installs dynamic content compression support. *PLEASE NOTE* - enabling dynamic compression always gives you more efficient use of bandwidth, but if your server's processor utilization is already very high, the CPU load imposed by dynamic compression might make your site perform more slowly.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,9 +24,4 @@ default['iis']['pubroot']    = "#{ENV['SYSTEMDRIVE']}\\inetpub"
 default['iis']['docroot']    = "#{iis['pubroot']}\\wwwroot"
 default['iis']['log_dir']    = "#{iis['pubroot']}\\logs\\LogFiles"
 default['iis']['cache_dir']  = "#{iis['pubroot']}\\temp"
-
-if Opscode::IIS::Helper.older_than_windows2008r2?
-  default['iis']['components'] = %w{Web-Server}
-else
-  default['iis']['components'] = %w{IIS-WebServerRole}
-end
+default['iis']['components'] = %w{}

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,4 +24,4 @@ default['iis']['pubroot']    = "#{ENV['SYSTEMDRIVE']}\\inetpub"
 default['iis']['docroot']    = "#{iis['pubroot']}\\wwwroot"
 default['iis']['log_dir']    = "#{iis['pubroot']}\\logs\\LogFiles"
 default['iis']['cache_dir']  = "#{iis['pubroot']}\\temp"
-default['iis']['components'] = %w{}
+default['iis']['components'] = []

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,16 +18,10 @@
 # limitations under the License.
 #
 
-default = %w{}
-
 # Always add this, so that we don't require this to be added if we want to add other components
-if Opscode::IIS::Helper.older_than_windows2008r2?
-  default << 'Web-Server'
-else
-  default << 'IIS-WebServerRole'
-end
+default = Opscode::IIS::Helper.older_than_windows2008r2? ? 'Web-Server' : 'IIS-WebServerRole'
 
-((default << node['iis']['components']).flatten!).each do |feature|
+(node['iis']['components'] + [default]).each do |feature|
   windows_feature feature do
     action :install
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,16 @@
 # limitations under the License.
 #
 
-node['iis']['components'].each do |feature|
+default = %w{}
+
+# Always add this, so that we don't require this to be added if we want to add other components
+if Opscode::IIS::Helper.older_than_windows2008r2?
+  default << 'Web-Server'
+else
+  default << 'IIS-WebServerRole'
+end
+
+((default << node['iis']['components']).flatten!).each do |feature|
   windows_feature feature do
     action :install
   end

--- a/recipes/mod_aspnet45.rb
+++ b/recipes/mod_aspnet45.rb
@@ -1,5 +1,5 @@
 #
-# Author:: Seth Chisamore (<schisamo@opscode.com>)
+# Author:: Blair Hamilton (<blairham@me.com>)
 # Cookbook Name:: iis
 # Recipe:: mod_aspnet45
 #

--- a/recipes/mod_aspnet45.rb
+++ b/recipes/mod_aspnet45.rb
@@ -1,0 +1,34 @@
+#
+# Author:: Seth Chisamore (<schisamo@opscode.com>)
+# Cookbook Name:: iis
+# Recipe:: mod_aspnet45
+#
+# Copyright 2011, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe "iis"
+include_recipe "iis::mod_isapi"
+
+if Opscode::IIS::Helper.older_than_windows2008r2?
+  features = %w{NET-Framework}
+else
+  features = %w{NetFx4Extended-ASPNET45 IIS-NetFxExtensibility45 IIS-ASPNET45}
+end
+
+features.each do |feature|
+  windows_feature feature do
+    action :install
+  end
+end


### PR DESCRIPTION
This adds the ASPNT45 mod so if you are using .NET4.5 you can use this module instead.

I've also moved the logic for including the WebServer into the default cookbook that way you don't have to include it if you plan on adding other components.