### PR TITLE
Updates Readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Creates an application pool in IIS.
 - `max_proc` - specifies the number of worker processes associated with the pool.
 - `thirty_two_bit` - set the pool to run in 32 bit mode, valid values are :true or :false
 - `no_managed_code` - allow Unmanaged Code in setting up IIS app pools
-- `pool_identity` - the account identity that they app pool will run as
+- `pool_identity` - the account identity that they app pool will run as, valid values are :SpecificUser, :NetworkService, :LocalService, :LocalSystem, :ApplicationPoolIdentity
 - `pool_username` - username for the identity for the application pool
 - `pool_password` password for the identity for the application pool
 


### PR DESCRIPTION
The following syntax is invalid: 'pool_identity 'SpecificUser'. This pull request clarifies that you must use the 'symbol' syntax e.g.. 'pool_identity :SpecificUser'