### PR TITLE
Fixed host_header changes not applying on config

### DIFF
--- a/providers/site.rb
+++ b/providers/site.rb
@@ -64,7 +64,7 @@ action :config do
     doc = Document.new(xml)
     is_new_bindings = is_new_value?(doc.root, "SITE/@bindings", @new_resource.bindings.to_s)
     is_new_physical_path = is_new_or_empty_value?(doc.root, "SITE/site/application/virtualDirectory/@physicalPath", @new_resource.path.to_s)
-    is_new_port_host_provided = XPath.first(doc.root, "SITE/@bindings").to_s.include?("#{@new_resource.protocol.to_s}/*:#{@new_resource.port}:#{@new_resource.host_header}")
+    is_new_port_host_provided = !"#{XPath.first(doc.root, "SITE/@bindings").to_s},".include?("#{@new_resource.protocol.to_s}/*:#{@new_resource.port}:#{@new_resource.host_header},")
     is_new_site_id = is_new_value?(doc.root, "SITE/site/@id", @new_resource.site_id.to_s)
     is_new_log_directory = is_new_or_empty_value?(doc.root,"SITE/logFiles/@directory",@new_resource.log_directory.to_s)
     is_new_log_period = is_new_or_empty_value?(doc.root, "SITE/logFile/@period", @new_resource.log_period.to_s)


### PR DESCRIPTION
I noticed `host_header` changes would only take effect on add, not on `config`.

This seems to be because `is_new_port_host_provided` is checking to see if the binding combo is already included, which it never will be. This prevents the binding being added on line 79. This commit just flips the logic.

It also fixes an edge-case where a config change with a host-header of `localhost-foo` -> `localhost` wouldn't get applied (since technically `http/*:80:localhost` is included in `http/*:80:localhost-foo`).