### PR TITLE
Updated iis_pool provider to allow gMSA for pool identity #151

### DIFF
--- a/providers/pool.rb
+++ b/providers/pool.rb
@@ -252,6 +252,15 @@ def configure
       cmd << " \"/[name='#{new_resource.pool_name}'].processModel.password:#{new_resource.pool_password}\""
       Chef::Log.debug(cmd)
       shell_out!(cmd)
+    elsif ((new_resource.pool_username && new_resource.pool_username != '') and
+      (new_resource.pool_password.nil? || new_resource.pool_username == '') and
+      is_new_user_name)
+      @was_updated = true
+      cmd = "#{appcmd(node)} set config /section:applicationPools"
+      cmd << " \"/[name='#{new_resource.pool_name}'].processModel.identityType:SpecificUser\""
+      cmd << " \"/[name='#{new_resource.pool_name}'].processModel.userName:#{new_resource.pool_username}\""
+      Chef::Log.debug(cmd)
+      shell_out!(cmd)
     elsif ((new_resource.pool_username.nil? || new_resource.pool_username == '') and
       (new_resource.pool_password.nil? || new_resource.pool_username == '') and
       (is_new_identity_type and new_resource.pool_identity != "SpecificUser"))


### PR DESCRIPTION
Changes allow for gMSA to be used in configurations of pools, which do not get passwords set manually. More info on gMSA below;

http://blogs.technet.com/b/askpfeplat/archive/2012/12/17/windows-server-2012-group-managed-service-accounts.aspx