### PR TITLE
Update vdir.rb

### DIFF
--- a/providers/vdir.rb
+++ b/providers/vdir.rb
@@ -36,7 +36,7 @@ action :add do
     cmd << " /allowSubDirConfig:#{new_resource.allow_sub_dir_config}" if new_resource.allow_sub_dir_config
 
     Chef::Log.info(cmd)
-    shell_out!(cmd, {:returns => [0,42]})
+    shell_out!(cmd, {:returns => [0,42,183]})
     new_resource.updated_by_last_action(true)
     Chef::Log.info("#{new_resource} added new virtual directory to application: '#{new_resource.application_name}'")
   else


### PR DESCRIPTION
Line 39:     add error code 183 for appcmd.exe to ignore errors when the vdir already exists. 

When you create a vdir under an application <site>\<application>\<vdir> and run chef-client twice, it will return the 183 error causing the chef-run to fail. This does not occur when the vdir is only one level down, as in <site>\<vdir>.

The iis_vdir provider does not take a "returns [x,y,z]" attribute so the error code must be added to the vdir.rb provider.