### PR TITLE
Issue #168, fixes issues in enhancement #156 that introduced two syntax ...

### DIFF
--- a/providers/config.rb
+++ b/providers/config.rb
@@ -27,7 +27,7 @@ include Opscode::IIS::Helper
 action :config do
   cmd = "#{appcmd(node)} set config #{new_resource.cfg_cmd}"
   Chef::Log.debug(cmd)
-  shell_out!(cmd, returns: new_resource.returns)
+  shell_out!(cmd, :returns => new_resource.returns)
   Chef::Log.info('IIS Config command run')
   new_resource.updated_by_last_action(true)
 end

--- a/providers/pool.rb
+++ b/providers/pool.rb
@@ -277,7 +277,7 @@ private
 
 def configure_application_pool(condition, config, add_remove = '')
   unless condition
-    returns
+    :returns
   end
 
   @was_updated = true


### PR DESCRIPTION
...bugs that crashes chef runs with the error "NameError: No resource, method, or local variable named returns' forChef::Provider::IisPool"