### PR TITLE
Win32 include only on Windows

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -28,10 +28,10 @@ module Opscode
 
       if RUBY_PLATFORM =~ /mswin|mingw32|windows/
         require 'chef/win32/version'
+        require 'win32/registry'
       end
 
       require 'rexml/document'
-      require 'win32/registry'
 
       include REXML
       include Windows::Helper


### PR DESCRIPTION
Fix win32/registry import (was breaking on Linux platform on branch enhancement-iis_version_detection, due to the fix to #185)