### PR TITLE
Changes default location of log_files

### DIFF
--- a/resources/site.rb
+++ b/resources/site.rb
@@ -30,7 +30,7 @@ attribute :host_header, kind_of: String, default: nil
 attribute :bindings, kind_of: String, default: nil
 attribute :application_pool, kind_of: String, default: nil
 attribute :options, kind_of: String, default: ''
-attribute :log_directory, kind_of: String, default: "#{node['iis']['pubroot']}\\logs\\LogFiles"
+attribute :log_directory, kind_of: String, default: "#{node['iis']['log_dir']}"
 attribute :log_period, kind_of: Symbol, default: :Daily, equal_to: [:Daily, :Hourly, :MaxSize, :Monthly, :Weekly]
 attribute :log_truncsize, kind_of: Integer, default: 1_048_576
 


### PR DESCRIPTION
The value` ['iis']['log_dir']` in the default.rb is never used leading to confusion of why all logs were going to c:\inetpub instead of the configured location. 

Shouldn't break anything since default values are the same

Before
`#{node['iis']['pubroot']}\\logs\\LogFiles`   = c:\inetpub\logs\LogFiles
After
`#{node['iis']['log_dir']}` = c:\inetpub\logs\LogFiles"