### PR TITLE
Adds an example of how to increase file upload size

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ end
 ```
 
 ```ruby
+# Increase file upload size for 'MySite'
+iis_config "\"MySite\" /section:requestfiltering /requestlimits.maxallowedcontentlength:50000000" do
+  action :config
+end
+```
+
+```ruby
 # Loads an array of commands from the node
 cfg_cmds = node['iis']['cfg_cmd']
 cfg_cmds.each do |cmd|


### PR DESCRIPTION
This example is natively idempotent, and adds a new value to the web.config xml to increase the default size of uploads from 30000000 bytes
Hope it is helpful to someone else since it took me forever to figure out. 

http://www.iis.net/configreference/system.webserver/security/requestfiltering/requestlimits
http://powershell.com/cs/forums/p/12690/22632.aspx