### PR TITLE
Fix iis_pool stderr output on initialize

### DIFF
--- a/providers/pool.rb
+++ b/providers/pool.rb
@@ -108,7 +108,7 @@ def load_current_resource
       @current_resource.running = false
     end
   else
-    log "Failed to run iis_pool action :load_current_resource, #{cmd_current_values.stderr}" do
+    log "Failed to run iis_pool action :load_current_resource, #{cmd.stderr}" do
       level :warn
     end
   end


### PR DESCRIPTION
The unhappy path of displaying the stderr was using the wrong variable name